### PR TITLE
Переключение версии SDK на 20.4100 в ветке rc-20.4100

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('pipeline') _
 
-def version = '20.4000'
+def version = '20.4100'
 
 node ('controls') {
     checkout_pipeline("rc-${version}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "saby-i18n",
-   "version": "20.4000.0",
+   "version": "20.4100.0",
    "repository": {
       "type": "git",
       "url": "git@github.com:saby/i18n.git"
@@ -19,6 +19,6 @@
       "test:coverage": "wasaby-cli --tasks=startTest --node --coverage"
    },
    "devDependencies": {
-      "wasaby-cli": "git+https://platform-git.sbis.ru/saby/wasaby-cli.git#rc-20.4000"
+      "wasaby-cli": "git+https://platform-git.sbis.ru/saby/wasaby-cli.git#rc-20.4100"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/7310/".